### PR TITLE
Update to 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 language: julia
 os:
-#  - osx
   - linux
 julia:
-  - 0.6
-#  - 0.7
-#  - nightly
+  - 0.7
+  - 1.0
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - julia: 1.0
+
 notifications:
   email: false
 addons:
     apt_packages:
         - gfortran
 after_success:
-  - julia -e 'cd(Pkg.dir("SVDD")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+  - julia -e 'import Pkg; cd(Pkg.dir("SVDD")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,326 @@
+[[Arpack]]
+deps = ["BinaryProvider", "Libdl", "LinearAlgebra", "Random", "SparseArrays", "Test"]
+git-tree-sha1 = "1ce1ce9984683f0b6a587d5bdbc688ecb480096f"
+uuid = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
+version = "0.3.0"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BinDeps]]
+deps = ["Compat", "Libdl", "SHA", "URIParser"]
+git-tree-sha1 = "12093ca6cdd0ee547c39b1870e0c9c3f154d9ca9"
+uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+version = "0.8.10"
+
+[[BinaryProvider]]
+deps = ["Libdl", "Pkg", "SHA", "Test"]
+git-tree-sha1 = "9930c1a6cd49d9fcd7218df6be417e6ae4f1468a"
+uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+version = "0.5.2"
+
+[[Calculus]]
+deps = ["Compat"]
+git-tree-sha1 = "f60954495a7afcee4136f78d1d60350abd37a409"
+uuid = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
+version = "0.4.1"
+
+[[CommonSubexpressions]]
+deps = ["Test"]
+git-tree-sha1 = "efdaf19ab11c7889334ca247ff4c9f7c322817b0"
+uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
+version = "0.2.0"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "2d9e14d19bad3f9ad5cc5e4cffabc3cfa59de825"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "1.3.0"
+
+[[DataStructures]]
+deps = ["InteractiveUtils", "OrderedCollections", "Random", "Serialization", "Test"]
+git-tree-sha1 = "8fc6e166e24fda04b2b648d4260cdad241788c54"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.14.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[DiffResults]]
+deps = ["Compat", "StaticArrays"]
+git-tree-sha1 = "db8acf46717b13d6c48deb7a12007c7f85a70cf7"
+uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+version = "0.0.3"
+
+[[DiffRules]]
+deps = ["Random", "Test"]
+git-tree-sha1 = "c49ec69428ffea0c1d1bbdc63d1a70f5df5860ad"
+uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
+version = "0.0.7"
+
+[[Distributed]]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[Distributions]]
+deps = ["Distributed", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns", "Test"]
+git-tree-sha1 = "c24e9b6500c037673f0241a2783472b8c3d080c7"
+uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
+version = "0.16.4"
+
+[[EzXML]]
+deps = ["BinaryProvider", "Libdl", "Printf", "Test"]
+git-tree-sha1 = "5623d1486bfaadd815f5c4ca501adda02b5337f1"
+uuid = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
+version = "0.9.0"
+
+[[ForwardDiff]]
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "InteractiveUtils", "LinearAlgebra", "NaNMath", "Random", "SparseArrays", "SpecialFunctions", "StaticArrays", "Test"]
+git-tree-sha1 = "8425a7d4e060bc2ded32d090bce910a187d6cce7"
+uuid = "f6369f11-7733-5829-9624-2563aa707210"
+version = "0.9.0"
+
+[[InteractiveUtils]]
+deps = ["LinearAlgebra", "Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[Ipopt]]
+deps = ["BinDeps", "BinaryProvider", "Compat", "Libdl", "MathOptInterface", "MathProgBase"]
+git-tree-sha1 = "b94462673702e3701852bbff61ff8bbf96feb351"
+uuid = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
+version = "0.4.3"
+
+[[JSON]]
+deps = ["Dates", "Distributed", "Mmap", "Sockets", "Test", "Unicode"]
+git-tree-sha1 = "fec8e4d433072731466d37ed0061b3ba7f70eeb9"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.19.0"
+
+[[JuMP]]
+deps = ["Calculus", "Compat", "ForwardDiff", "MathProgBase", "Pkg", "ReverseDiffSparse"]
+git-tree-sha1 = "3716c8cae07d5056e7b9981d2d4dde239bd9c1d1"
+uuid = "4076af6c-e467-56ae-b986-b466b2749572"
+version = "0.18.4"
+
+[[LearnBase]]
+deps = ["LinearAlgebra", "SparseArrays", "StatsBase", "Test"]
+git-tree-sha1 = "c4b5da6d68517f46f70ed5157b28336b56cd2ff3"
+uuid = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"
+version = "0.2.2"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[MLKernels]]
+deps = ["LinearAlgebra", "SpecialFunctions", "Statistics", "Test"]
+git-tree-sha1 = "456c6aa2928ae85064ef1d28b80d04fafed08986"
+repo-rev = "master"
+repo-url = "https://github.com/trthatcher/MLKernels.jl.git"
+uuid = "48eadcf2-8ff1-11e8-289d-f103432a0bb3"
+version = "0.4.0"
+
+[[MLLabelUtils]]
+deps = ["LearnBase", "MappedArrays", "StatsBase", "Test"]
+git-tree-sha1 = "2f5309e393467e8d40231957ba17582cba84e8c1"
+uuid = "66a33bbf-0c2b-5fc8-a008-9da813334f0a"
+version = "0.4.1"
+
+[[MappedArrays]]
+deps = ["Test"]
+git-tree-sha1 = "923441c5ac942b60bd3a842d5377d96646bcbf46"
+uuid = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
+version = "0.2.1"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MathOptInterface]]
+deps = ["Compat", "Unicode"]
+git-tree-sha1 = "d7427366a571b41214fa51e2e33b7a64c8950e5f"
+uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+version = "0.6.2"
+
+[[MathProgBase]]
+deps = ["Compat"]
+git-tree-sha1 = "3bf2e534e635df810e5f4b4f1a8b6de9004a0d53"
+uuid = "fdba3010-5040-5b88-9595-932c9decdf73"
+version = "0.7.7"
+
+[[Memento]]
+deps = ["Compat", "JSON", "Nullables", "Syslogs", "TimeZones"]
+git-tree-sha1 = "c4ade3575bcc2c180cfa14cf8b3b63eebca51629"
+uuid = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
+version = "0.10.0"
+
+[[Missings]]
+deps = ["Dates", "InteractiveUtils", "SparseArrays", "Test"]
+git-tree-sha1 = "adc26d2ee85a49c413464110d922cf21efc9d233"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "0.3.1"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Mocking]]
+deps = ["Compat", "Dates"]
+git-tree-sha1 = "4bf69aaf823b119b034e091e16b18311aa191663"
+uuid = "78c3b35d-d492-501b-9361-3d52fe80e533"
+version = "0.5.7"
+
+[[NaNMath]]
+deps = ["Compat"]
+git-tree-sha1 = "ce3b85e484a5d4c71dd5316215069311135fa9f2"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "0.3.2"
+
+[[Nullables]]
+deps = ["Compat"]
+git-tree-sha1 = "ae1a63457e14554df2159b0b028f48536125092d"
+uuid = "4d1e1d77-625e-5b40-9113-a560ec7a8ecd"
+version = "0.0.8"
+
+[[OrderedCollections]]
+deps = ["Random", "Serialization", "Test"]
+git-tree-sha1 = "85619a3f3e17bb4761fe1b1fd47f0e979f964d5b"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.0.2"
+
+[[PDMats]]
+deps = ["Arpack", "LinearAlgebra", "SparseArrays", "SuiteSparse", "Test"]
+git-tree-sha1 = "9e3e7a5c9b8cfdba8c01a1bcae38fe0144936fda"
+uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
+version = "0.9.5"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[QuadGK]]
+deps = ["DataStructures", "LinearAlgebra", "Test"]
+git-tree-sha1 = "7e8dff9c205f36eceaf6e62a43ff851637ca45fc"
+uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+version = "2.0.2"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[ReverseDiffSparse]]
+deps = ["Calculus", "Compat", "DataStructures", "ForwardDiff", "MathProgBase", "NaNMath"]
+git-tree-sha1 = "2c445d3c0a519376c950023ac67079bb71418f9b"
+uuid = "89212889-6d3f-5f97-b412-7825138f6c9c"
+version = "0.8.4"
+
+[[Rmath]]
+deps = ["BinaryProvider", "Libdl", "Random", "Statistics", "Test"]
+git-tree-sha1 = "9a6c758cdf73036c3239b0afbea790def1dabff9"
+uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
+version = "0.5.0"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SortingAlgorithms]]
+deps = ["DataStructures", "Random", "Test"]
+git-tree-sha1 = "03f5898c9959f8115e30bc7226ada7d0df554ddd"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "0.3.1"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[SpecialFunctions]]
+deps = ["BinDeps", "BinaryProvider", "Libdl", "Test"]
+git-tree-sha1 = "0b45dc2e45ed77f445617b99ff2adf0f5b0f23ea"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "0.7.2"
+
+[[StaticArrays]]
+deps = ["InteractiveUtils", "LinearAlgebra", "Random", "Statistics", "Test"]
+git-tree-sha1 = "ebc5c2a27d91d5ec611a9861168182e2168effd3"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "0.9.2"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[StatsBase]]
+deps = ["DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "Test"]
+git-tree-sha1 = "723193a13e8078cec6dcd0b8fe245c8bfd81690e"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.25.0"
+
+[[StatsFuns]]
+deps = ["Rmath", "SpecialFunctions", "Test"]
+git-tree-sha1 = "d14bb7b03defd2deaa5675646f6783089e0556f0"
+uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+version = "0.7.0"
+
+[[SuiteSparse]]
+deps = ["Libdl", "LinearAlgebra", "SparseArrays"]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
+[[Syslogs]]
+deps = ["Compat", "Nullables"]
+git-tree-sha1 = "d3e512a044cc8873c741d88758f8e1888c7c47d3"
+uuid = "cea106d9-e007-5e6c-ad93-58fe2094e9c4"
+version = "0.2.0"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TimeZones]]
+deps = ["Compat", "EzXML", "Mocking", "Nullables"]
+git-tree-sha1 = "4a4ab113913e19ad62b67e6c5c056509eac00c19"
+uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
+version = "0.8.2"
+
+[[URIParser]]
+deps = ["Test", "Unicode"]
+git-tree-sha1 = "6ddf8244220dfda2f17539fa8c9de20d6c575b69"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.4.0"
+
+[[UUIDs]]
+deps = ["Random"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,16 @@
+name = "SVDD"
+uuid = "83536b18-e0df-11e8-1e3f-f991e449cee4"
+authors = ["Holger Trittenbach", "Adrian Englhardt"]
+version = "0.1.0"
+
+[deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MLKernels = "48eadcf2-8ff1-11e8-289d-f103432a0bb3"
+MLLabelUtils = "66a33bbf-0c2b-5fc8-a008-9da813334f0a"
+Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -10,11 +10,16 @@ The package has been developed as part of a benchmark suite for [active-learning
 > Holger Trittenbach, Adrian Englhardt, Klemens Böhm, "An Overview and a Benchmark of Active Learning for One-Class Classification" [arXiv:1808.04759](https://arxiv.org/abs/1808.04759), 14 Aug 2018
 
 ## Installation
-This package works with Julia 0.6. We plan to upgrade to the latest Julia version once all dependencies support 1.0.
-This package is not registered yet. Please use the following command to clone the package.
+This package works with Julia 1.0.
+This package is not registered yet. Please use the following command to add the package with Pkg3.
 ```Julia
-Pkg.clone("https://github.com/englhardt/SVDD.jl.git")
+using Pkg
+Pkg.add("https://github.com/englhardt/SVDD.jl.git")
 ```
+
+The results presented in the paper base on a previous version of the package and on Julia 0.6.
+To reproduce the experiment results from the paper, use the old package manager (with Pkg.clone) and checkout SVDD.jl at tag `v1.0`.
+
 ## Overview
 
 [One-class classifiers](https://en.wikipedia.org/wiki/One-class_classification) learn to identify if objects belong to a specific class, often used for outlier detection.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7
 MLKernels
 MLLabelUtils
 JuMP

--- a/src/SVDD.jl
+++ b/src/SVDD.jl
@@ -15,7 +15,7 @@ include("init_strategies/strategies_gamma.jl")
 include("init_strategies/strategies_combined.jl")
 
 using Memento
-using Compat: @__MODULE__
+using LinearAlgebra, Random
 
 const LOGGER = getlogger(@__MODULE__)
 

--- a/src/classifiers/classifier_svdd.jl
+++ b/src/classifiers/classifier_svdd.jl
@@ -20,7 +20,7 @@ function predict(model::SVDDClassifier, target::Array{T,2}) where T <: Real
             2 * sum(α[i] * kernel(model.kernel_fct, model.data[:,i], z) for i in eachindex(α)) +
             model.const_term
     end
-    return vec(sqrt.(mapslices(predict_observation, target, 1)) - model.R)
+    return vec(sqrt.(mapslices(predict_observation, target, dims=1)) .- model.R)
 end
 
 function get_R_and_const_term(model::SVDDClassifier)

--- a/src/classifiers/classifier_svdd_neg.jl
+++ b/src/classifiers/classifier_svdd_neg.jl
@@ -97,10 +97,10 @@ end
 function get_support_vectors(model::SVDDneg)
     ULin = merge_pools(model.pools, :U, :Lin)
     length(ULin) > 0 || throw(ModelInvariantException("SVDDneg requires samples in pool :Lin or :U."))
-    sv = filter!(x -> x in ULin, find((model.alpha_values .> OPT_PRECISION) .& (model.alpha_values .< (model.C1 - OPT_PRECISION))))
+    sv = filter!(x -> x in ULin, findall((model.alpha_values .> OPT_PRECISION) .& (model.alpha_values .< (model.C1 - OPT_PRECISION))))
     if haskey(model.pools, :Lout)
         sv = append!(sv, filter!(x -> x in model.pools[:Lout],
-                                 find((model.alpha_values .> OPT_PRECISION) .& (model.alpha_values .< (model.C2 - OPT_PRECISION)))))
+                                 findall((model.alpha_values .> OPT_PRECISION) .& (model.alpha_values .< (model.C2 - OPT_PRECISION)))))
     end
     return sv
 end

--- a/src/classifiers/classifier_svdd_vanilla.jl
+++ b/src/classifiers/classifier_svdd_vanilla.jl
@@ -63,7 +63,7 @@ function solve!(model::VanillaSVDD, solver)
 end
 
 function get_support_vectors(model::VanillaSVDD)
-    find((model.alpha_values .> OPT_PRECISION) .& (model.alpha_values .< (model.C - OPT_PRECISION)))
+    findall((model.alpha_values .> OPT_PRECISION) .& (model.alpha_values .< (model.C - OPT_PRECISION)))
 end
 
 get_alpha_prime(model::VanillaSVDD) = model.alpha_values

--- a/src/init_strategies/strategies_gamma.jl
+++ b/src/init_strategies/strategies_gamma.jl
@@ -10,7 +10,7 @@ calculate_gamma(model, strategy::FixedGammaStrategy) = strategy.kernel
 Original publication:
 Silverman, Bernard W. Density estimation for statistics and data analysis. Routledge, 2018.
 """
-type RuleOfThumbSilverman <: InitializationStrategyGamma end
+struct RuleOfThumbSilverman <: InitializationStrategyGamma end
 
 function calculate_gamma(model, strategy::RuleOfThumbSilverman)
     return (size(model.data, 2) * (size(model.data, 1) + 2) / 4.0)^(-1.0 / (size(model.data,1) + 4.0))
@@ -20,7 +20,7 @@ end
 Original publication:
 Scott, David W. Multivariate density estimation: theory, practice, and visualization. John Wiley & Sons, 2015.
 """
-type RuleOfThumbScott <: InitializationStrategyGamma end
+struct RuleOfThumbScott <: InitializationStrategyGamma end
 
 function calculate_gamma(model, strategy::RuleOfThumbScott)
     return size(model.data, 2)^(-1.0/(size(model.data,1) + 4))

--- a/src/svdd_util.jl
+++ b/src/svdd_util.jl
@@ -1,17 +1,17 @@
 
 function merge_pools(pools, names...)
     (names[1] == [] || MLLabelUtils.islabelenc(collect(names), SVDD.learning_pool_enc)) || throw(ArgumentError("$(collect(names)) is not a valid label encoding."))
-    return reduce((r, key) -> vcat(r, haskey(pools, key) ? pools[key] : Int64[]), Int64[], unique(names))
+    return reduce((r, key) -> vcat(r, haskey(pools, key) ? pools[key] : Int64[]), unique(names); init=Int64[])
 end
 
 classify(x::Number) = x > 0 ? :outlier : :inlier
 
 function adjust_kernel_matrix(K::Array{T, 2}; tolerance = 1e-15, warn_threshold = 1e-8) where T <: Real
     info(LOGGER, "Adjusting Kernel Matrix.")
-    F = eigfact(K)
-    eltype(F[:values]) <: Complex && throw(ArgumentError("Matrix K has complex eigenvalues."))
-    F[:values][F[:values] .< tolerance] = 0.0
-    K_adjusted::Array{Float64, 2} = F[:vectors] * diagm(F[:values]) * inv(F[:vectors])
+    F = eigen(K)
+    eltype(F.values) <: Complex && throw(ArgumentError("Matrix K has complex eigenvalues."))
+    F.values[F.values .< tolerance] .= 0.0
+    K_adjusted::Array{Float64, 2} = F.vectors * diagm(0 => F.values) * inv(F.vectors)
     K_diff = abs.(K_adjusted - K)
     sum_adjustment = sum(K_diff)
     max_adjustment = maximum(K_diff)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6
+julia 0.7
 Coverage

--- a/test/classifiers/classifier_ssad_test.jl
+++ b/test/classifiers/classifier_ssad_test.jl
@@ -61,7 +61,7 @@
     @testset "predict" begin
         predictions = SVDD.predict(ssad, dummy_data)
         @test length(predictions) == size(dummy_data, 2)
-        @test predictions[1] == SVDD.predict(ssad, [1.0 2.0]')[1]
+        @test predictions[1] == SVDD.predict(ssad, hcat([1.0, 2.0]))[1]
     end
 
     @testset "params" begin

--- a/test/classifiers/classifier_svdd_vanilla_test.jl
+++ b/test/classifiers/classifier_svdd_vanilla_test.jl
@@ -31,7 +31,7 @@
     @testset "predict" begin
         predictions = SVDD.predict(vanilla_svdd, dummy_data)
         @test length(predictions) == size(dummy_data, 2)
-        @test predictions[1] == SVDD.predict(vanilla_svdd, [1.0 4.0]')[1]
+        @test predictions[1] == SVDD.predict(vanilla_svdd, hcat([1.0, 4.0]))[1]
     end
 
     @testset "params" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,8 @@ using SVDD
 using Ipopt
 using StatsBase, Distributions
 using MLKernels, MLLabelUtils
-using Base.Test
+using Test
+using LinearAlgebra, Random
 
 TEST_SOLVER = IpoptSolver(print_level=0)
 

--- a/test/svdd_util_test.jl
+++ b/test/svdd_util_test.jl
@@ -27,22 +27,22 @@
 
     @testset "adjust kernel" begin
         K1 = [2 -1 0; -1 2 -1; 0 -1 2]
-        @assert all(eig(K1)[1] .> 0)
+        @assert all(eigen(K1).values .> 0)
         @test K1 ≈ SVDD.adjust_kernel_matrix(K1)
 
         K2 = [1 2; 2 1]
-        @assert any(eig(K2)[1] .< 0)
+        @assert any(eigen(K2).values .< 0)
         K2_adjusted = SVDD.adjust_kernel_matrix(K2, warn_threshold = 2)
         @test !(K2 ≈ K2_adjusted)
-        @test all(eig(K2_adjusted)[1] .>= 0.0)
+        @test all(eigen(K2_adjusted).values .>= 0.0)
 
-        srand(42)
+        Random.seed!(42)
         dummy_data, _ = generate_mvn_with_outliers(2, 100, 42, true, true)
         model = SVDD.VanillaSVDD(dummy_data)
         init_strategy = SVDD.FixedParameterInitialization(MLKernels.GaussianKernel(4), 0.1)
         SVDD.initialize!(model, init_strategy)
         K_old = copy(model.K)
-        @assert any(eig(model.K)[1] .< 0)
+        @assert any(eigen(model.K).values .< 0)
 
         @test_throws ArgumentError SVDD.adjust_kernel_matrix([3 -2; 4 -1])
     end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -2,10 +2,10 @@
 function generate_mvn_with_outliers(n_dim, n_observations,
     seed=123, normalized=true, incl_outliers=true)
 
-    srand(seed)
-    norm_distribution = MvNormal(zeros(n_dim), eye(n_dim))
+    Random.seed!(seed)
+    norm_distribution = MvNormal(zeros(n_dim), Matrix(1.0I, n_dim, n_dim))
     inliers = rand(norm_distribution, n_observations)
-    tmp = [rand(MvNormal([x, y], eye(2)), 2) for x in [4,-4] for y in [4,-4]]
+    tmp = [rand(MvNormal([x, y], Matrix(1.0I, 2, 2)), 2) for x in [4,-4] for y in [4,-4]]
     outliers = vcat(hcat(tmp...), zeros(n_dim - 2, 8))
 
     if incl_outliers
@@ -16,7 +16,7 @@ function generate_mvn_with_outliers(n_dim, n_observations,
         labels = vcat(fill("inlier", n_observations))
     end
     if normalized
-        x = mapslices(normalize, x, 2)
+        x = mapslices(normalize, x, dims=2)
     end
     return (x, labels)
 end


### PR DESCRIPTION
This drops support for Julia 0.6 in favor of 0.7. Builds on 1.0 are still failing because of dependency on [MLKernels.jl](https://github.com/trthatcher/MLKernels.jl).
